### PR TITLE
feat: add raspberry pi 64-bit os installation instructions for docker

### DIFF
--- a/installation/raspberry_pi/1_setup_docker_apt_repo.sh
+++ b/installation/raspberry_pi/1_setup_docker_apt_repo.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# REF:https://docs.docker.com/engine/install/debian/#install-using-the-repository 
+
+# Add Docker's official GPG key:
+sudo apt-get -y update
+sudo apt-get -y install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get -y update

--- a/installation/raspberry_pi/2_install_docker_pkgs.sh
+++ b/installation/raspberry_pi/2_install_docker_pkgs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+

--- a/installation/raspberry_pi/3_setup_docker_env.sh
+++ b/installation/raspberry_pi/3_setup_docker_env.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Create new docker group for non-root users
+sudo groupadd docker
+# Add the new docker group to the current user
+sudo usermod -aG docker $USER
+# Activate the new group settings
+newgrp docker
+
+# Update file permissions in case previous commands were run with sudo by mistake
+sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
+sudo chmod g+rwx "$HOME/.docker" -R
+
+# Enable auto start on reboot
+sudo systemctl enable docker.service
+sudo systemctl enable containerd.service
+
+# Create new folder for persistent stat-calc data
+sudo mkdir -p /opt/docker/statCalcData
+
+# Create new docker network for containers to share
+docker network create comlink

--- a/installation/raspberry_pi/README.md
+++ b/installation/raspberry_pi/README.md
@@ -1,0 +1,22 @@
+## Installation Instructions for Raspberry Pi OS 64-bit
+
+This folder contains an example `docker-compose.yml` file along with some sample shell scripts to be used for first time
+setup of docker package repositories, docker installation, and first time environment configuration for hosting both
+swgoh-comlink and stat-calc containers. Some adjustments may be required for individual environment specifics, but these
+should provide a solid foundation to use as templates.
+
+### Basic Usage
+After cloning this repository or downloading this folder contents:
+
+1. Modify the `docker-compose.yml` file to the specifics for your intended use.
+2. Execute the shell scripts (make sure the shell scripts are executable first, `sudo chmod +x *.sh`)
+3. Launch the containers using the `docker compose up` command
+
+```bash
+1_setup_docker_apt_repo.sh
+2_install_docker_pkgs.sh
+3_setup_docker_env.sh
+
+docker compose up
+```
+If all goes well, the result should be both the `swgoh-comlink` and `stat-calc` containers running.

--- a/installation/raspberry_pi/docker-compose.yml
+++ b/installation/raspberry_pi/docker-compose.yml
@@ -1,0 +1,49 @@
+networks:
+  comlink:
+    external: true
+
+services:
+  swgoh-comlink:
+    container_name: swgoh-comlink
+    image: ghcr.io/swgoh-utils/swgoh-comlink:latest
+    restart: always
+    environment:
+      APP_NAME: your_app_name
+    ports:
+      - 3200:3000
+    networks:
+      - comlink
+
+  health-check:
+    image: curlimages/curl
+    container_name: health_check
+    restart: unless-stopped
+    command: ["/bin/sh","-c", "sleep infinity"]
+    depends_on:
+      - swgoh-comlink
+    healthcheck:
+      test: curl -f http://swgoh-comlink:3000/readyz || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    networks:
+      - comlink
+
+  swgoh-stats:
+    container_name: swgoh-stats
+    image: ghcr.io/swgoh-utils/swgoh-stats:latest
+    restart: always
+    depends_on:
+      swgoh-comlink:
+        condition: service_started
+      health-check:
+        condition: service_healthy
+    environment:
+      CLIENT_URL: http://swgoh-comlink:3000
+      PORT: 3223
+    volumes:
+      - "/opt/docker/statCalcData:/app/statCalcData"
+    ports:
+      - 3223:3223
+    networks:
+      - comlink


### PR DESCRIPTION
Updating the repo to add installation instructions for docker compose use on raspberry pi 64-bit os